### PR TITLE
Fix trigger

### DIFF
--- a/.github/workflows/lint-action.yml
+++ b/.github/workflows/lint-action.yml
@@ -1,13 +1,6 @@
 name: Lint Action
 on:
-  workflow_dispatch:
-  push:
-    paths:
-      - ".github/workflows/lint-action.yml"
-  pull_request:
-    paths:
-      - ".github/workflows/**.yml"
-      - ".github/workflows/**.yaml"
+  workflow_call:
 
 permissions:
   contents: read

--- a/.github/workflows/lint-markdown.yml
+++ b/.github/workflows/lint-markdown.yml
@@ -1,12 +1,6 @@
 name: Lint Markdown
 on:
-  workflow_dispatch:
-  push:
-    paths:
-      - ".github/workflows/lint-markdown.yml"
-  pull_request:
-    paths:
-      - "**.md"
+  workflow_call:
 
 permissions:
   contents: read

--- a/.github/workflows/lint-yaml.yml
+++ b/.github/workflows/lint-yaml.yml
@@ -1,13 +1,6 @@
 name: Lint YAML
 on:
-  workflow_dispatch:
-  push:
-    paths:
-      - ".github/workflows/lint-yaml.yml"
-  pull_request:
-    paths:
-      - "**.yml"
-      - "**.yaml"
+  workflow_call:
 
 permissions:
   contents: read


### PR DESCRIPTION
error message:

```
error parsing called workflow "./.github/workflows/lint-action.yml@": workflow is not reusable as it is missing a `on.workflow_call` trigger
```
